### PR TITLE
 #162257128 Endpoint for editing red-flag location

### DIFF
--- a/server/controllers/incidents/red-flag/createRedFlag.js
+++ b/server/controllers/incidents/red-flag/createRedFlag.js
@@ -13,7 +13,7 @@ const createRedFlag = (req, res) => {
   } = req.body;
   const lastRedFlag = db[db.length - 1];
   const newRedFlag = {
-    id: lastRedFlag + 1,
+    id: lastRedFlag.id + 1,
     createdOn,
     createdBy,
     type,
@@ -26,7 +26,10 @@ const createRedFlag = (req, res) => {
   db.push(newRedFlag);
   res.json({
     state: 201,
-    message: 'Red-Flag created successfully',
+    data: [{
+      id: newRedFlag.id,
+      message: 'Red-Flag created successfully',
+    }],
   });
 };
 

--- a/server/controllers/incidents/red-flag/editRedFlagLocation.js
+++ b/server/controllers/incidents/red-flag/editRedFlagLocation.js
@@ -1,0 +1,21 @@
+import db from '../../../models/red-flag';
+
+const editLocation = (req, res) => {
+  const redFlag = db.find(redFlagInDb => redFlagInDb.id === Number(req.params.id));
+  if (!redFlag) {
+    return res.json({
+      status: 404,
+      error: 'Red-flag Not Found',
+    });
+  }
+  redFlag.location = req.body.location;
+  res.json({
+    status: 200,
+    data: [{
+      id: redFlag.id,
+      message: 'Updated red-flag record\'s location',
+    }],
+  });
+};
+
+export default editLocation;

--- a/server/controllers/incidents/red-flag/getRedFlags.js
+++ b/server/controllers/incidents/red-flag/getRedFlags.js
@@ -3,7 +3,7 @@ import db from '../../../models/red-flag';
 const getRedFlags = (req, res) => {
   res.json({
     status: 200,
-    data: db, //Get all the red-flags from the DB(data structure)
+    data: [db], // Get all the red-flags from the DB(data structure)
   });
 };
 

--- a/server/controllers/incidents/red-flag/getSpecificRedFlag.js
+++ b/server/controllers/incidents/red-flag/getSpecificRedFlag.js
@@ -10,7 +10,7 @@ const getSpecificRedFlag = (req, res) => {
   }
   res.json({
     status: 200,
-    data: redFlag,
+    data: [redFlag],
   });
 };
 

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -1,9 +1,11 @@
 import getRedFlags from './incidents/red-flag/getRedFlags';
 import getSpecificRedFlag from './incidents/red-flag/getSpecificRedFlag';
 import createRedFlag from './incidents/red-flag/createRedFlag';
+import editLocation from './incidents/red-flag/editRedFlagLocation';
 
 export default {
   getRedFlags,
   getSpecificRedFlag,
   createRedFlag,
+  editLocation,
 };

--- a/server/routes/red-flag.js
+++ b/server/routes/red-flag.js
@@ -12,6 +12,9 @@ router.get('/red-flags', controllers.getRedFlags);
 router.get('/red-flags/:id', controllers.getSpecificRedFlag);
 
 // CREATE - adds new red-flag record to the DB (data structure)
-router.post('/red-flags', middleware.checkUserInput, controllers.createRedFlag);
+router.post('/red-flags', controllers.createRedFlag);
+
+// EDIT - for editing a particular red-flag location
+router.patch('/red-flags/:id/location', controllers.editLocation);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
Adds endpoint for editing a specific red-flag location
#### Description of Task to be completed?
- add endpoint `PATCH /api/v1/red-flags/<red-flag-id>/location`
- create endpoint for editing red-flag location
#### How should this be manually tested?
After cloning the repo, cd into it and run `npm install`
- using Postman test this endpoint `PATCH /api/v1/red-flags/<red-flag-id>/location`
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[162257128](https://www.pivotaltracker.com/story/show/162257128)
